### PR TITLE
Ue4 style fixes

### DIFF
--- a/Source/WatsonSdk/Private/Common/Microphone.cpp
+++ b/Source/WatsonSdk/Private/Common/Microphone.cpp
@@ -10,13 +10,6 @@ UMicrophone::UMicrophone()
 	VoiceCaptureSize = 0;
 }
 
-UMicrophone::~UMicrophone()
-{
-	VoiceCapture->Shutdown();
-	VoiceCaptureBuffer.Empty();
-	VoiceCaptureSize = 0;
-}
-
 void UMicrophone::StartRecording()
 {
 	VoiceCaptureBuffer.Empty();
@@ -70,4 +63,11 @@ bool UMicrophone::IsTickable() const
 TStatId UMicrophone::GetStatId() const
 {
 	return TStatId();
+}
+
+void UMicrophone::BeginDestroy()
+{
+	VoiceCapture->Shutdown();
+	VoiceCaptureBuffer.Empty();
+	VoiceCaptureSize = 0;
 }

--- a/Source/WatsonSdk/Private/Services/Conversation.cpp
+++ b/Source/WatsonSdk/Private/Services/Conversation.cpp
@@ -23,7 +23,7 @@ TSharedPtr<FConversationMessageDelegate> UConversation::Message(const FString& W
 	HttpRequest->SetURL(Configuration.Url + "workspaces/" + Workspace + "/message?version=" + Configuration.Version);
 	HttpRequest->SetHeader(TEXT("User-Agent"), Configuration.UserAgent);
 	HttpRequest->SetHeader(TEXT("Content-Type"), "application/json");
-	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.encode());
+	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.Encode());
 	HttpRequest->SetContentAsString(Content);
 
 	TSharedPtr<FConversationMessageDelegate> Delegate = MakeShareable(new FConversationMessageDelegate);

--- a/Source/WatsonSdk/Private/Services/SpeechToText.cpp
+++ b/Source/WatsonSdk/Private/Services/SpeechToText.cpp
@@ -20,7 +20,7 @@ TSharedPtr<FSpeechToTextRecognizeDelegate> USpeechToText::Recognize(TArray<uint8
 	HttpRequest->SetURL(Configuration.Url + "recognize?model=" + AudioModel);
 	HttpRequest->SetHeader(TEXT("User-Agent"), Configuration.UserAgent);
 	HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("audio/l16;rate=16000;channels=1;"));
-	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.encode());
+	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.Encode());
 	HttpRequest->SetContent(AudioData);
 
 	TSharedPtr<FSpeechToTextRecognizeDelegate> Delegate = MakeShareable(new FSpeechToTextRecognizeDelegate);

--- a/Source/WatsonSdk/Private/Services/TextToSpeech.cpp
+++ b/Source/WatsonSdk/Private/Services/TextToSpeech.cpp
@@ -24,7 +24,7 @@ TSharedPtr<FTextToSpeechSynthesizeDelegate> UTextToSpeech::Synthesize(const FSyn
 	HttpRequest->SetHeader(TEXT("Accept"), TEXT("audio/l16;rate=16000;channels=1;"));
 	HttpRequest->SetHeader(TEXT("User-Agent"), Configuration.UserAgent);
 	HttpRequest->SetHeader(TEXT("Content-Type"), "application/json");
-	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.encode());
+	HttpRequest->SetHeader(TEXT("Authorization"), Authorization.Encode());
 	HttpRequest->SetContentAsString(Content);
 
 	TSharedPtr<FTextToSpeechSynthesizeDelegate> Delegate = MakeShareable(new FTextToSpeechSynthesizeDelegate);

--- a/Source/WatsonSdk/Private/Services/TextToSpeech.cpp
+++ b/Source/WatsonSdk/Private/Services/TextToSpeech.cpp
@@ -43,7 +43,7 @@ void UTextToSpeech::OnSynthesizeProgress(FHttpRequestPtr Request, int32 BytesSen
 	{
 		TSharedPtr<FSynthesisProgress> Progress = *ProgressPtr;
 		TSharedPtr<FSynthesizeResponse> SynthesisResponse = Progress->Response;
-		SynthesisResponse->audioLength = BytesReceived;
+		SynthesisResponse->AudioLength = BytesReceived;
 	}	
 }
 
@@ -54,7 +54,7 @@ void UTextToSpeech::OnSynthesizeComplete(FHttpRequestPtr Request, FHttpResponseP
 	{
 		TSharedPtr<FSynthesisProgress> Progress = *ProgressPtr;
 		TSharedPtr<FSynthesizeResponse> SynthesisResponse = Progress->Response;
-		SynthesisResponse->audioData = TArray<uint8>(Response->GetContent());
+		SynthesisResponse->AudioData = TArray<uint8>(Response->GetContent());
 		Progress->Delegate.Get()->ExecuteIfBound(SynthesisResponse, nullptr);
 		PendingSynthesisRequests.Remove(Request);
 	}

--- a/Source/WatsonSdk/Public/Common/Authorization.h
+++ b/Source/WatsonSdk/Public/Common/Authorization.h
@@ -7,8 +7,12 @@ USTRUCT()
 struct FAuthorization
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString username;
-	UPROPERTY() FString password;
+
+	UPROPERTY()
+	FString username;
+	
+	UPROPERTY()
+	FString password;
 	
 	FAuthorization() {}
 	FAuthorization(FString username, FString password) :

--- a/Source/WatsonSdk/Public/Common/Authorization.h
+++ b/Source/WatsonSdk/Public/Common/Authorization.h
@@ -9,18 +9,18 @@ struct FAuthorization
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString username;
+	FString Username;
 	
 	UPROPERTY()
-	FString password;
+	FString Password;
 	
 	FAuthorization() {}
 	FAuthorization(FString username, FString password) :
-		username(username),
-		password(password)
+		Username(username),
+		Password(password)
 	{}
 
-	FString encode() {
-		return "Basic " + FBase64::Encode(username + ":" + password);
+	FString Encode() {
+		return "Basic " + FBase64::Encode(Username + ":" + Password);
 	}
 };

--- a/Source/WatsonSdk/Public/Common/Configuration.h
+++ b/Source/WatsonSdk/Public/Common/Configuration.h
@@ -6,9 +6,15 @@ USTRUCT()
 struct FConfiguration
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString Url;
-	UPROPERTY() FString UserAgent;
-	UPROPERTY() FString Version;
+	
+	UPROPERTY()
+	FString Url;
+	
+	UPROPERTY()
+	FString UserAgent;
+	
+	UPROPERTY()
+	FString Version;
 
 	FConfiguration() {}
 	FConfiguration(FString Url, FString UserAgent, FString Version) :

--- a/Source/WatsonSdk/Public/Common/Microphone.h
+++ b/Source/WatsonSdk/Public/Common/Microphone.h
@@ -22,7 +22,6 @@ public:
 	int32 VoiceCaptureSize;
 
 	UMicrophone();
-	~UMicrophone();
 
 	void StartRecording();
 	void StopRecording();
@@ -33,4 +32,6 @@ public:
 	bool IsTickableWhenPaused() const override;
 	bool IsTickable() const override;
 	TStatId GetStatId() const override;
+
+	virtual void BeginDestroy() override;
 };

--- a/Source/WatsonSdk/Public/Common/Microphone.h
+++ b/Source/WatsonSdk/Public/Common/Microphone.h
@@ -10,12 +10,16 @@ UCLASS()
 class WATSONSDK_API UMicrophone : public UObject, public FTickableGameObject
 {
 	GENERATED_BODY()
+
 private:
 	TSharedPtr<class IVoiceCapture> VoiceCapture;
 
 public:
-	UPROPERTY() TArray<uint8> VoiceCaptureBuffer;
-	UPROPERTY() int32 VoiceCaptureSize;
+	UPROPERTY()
+	TArray<uint8> VoiceCaptureBuffer;
+	
+	UPROPERTY()
+	int32 VoiceCaptureSize;
 
 	UMicrophone();
 	~UMicrophone();

--- a/Source/WatsonSdk/Public/Common/Speaker.h
+++ b/Source/WatsonSdk/Public/Common/Speaker.h
@@ -9,9 +9,13 @@ UCLASS()
 class WATSONSDK_API USpeaker : public UObject
 {
 	GENERATED_BODY()
+
 private:
-	UPROPERTY() UAudioComponent* AudioOutputComponent;
-	UPROPERTY() USoundWaveProcedural* AudioPCMComponent;
+	UPROPERTY()
+	UAudioComponent* AudioOutputComponent;
+	
+	UPROPERTY()
+	USoundWaveProcedural* AudioPCMComponent;
 
 public:
 	USpeaker();

--- a/Source/WatsonSdk/Public/Services/Conversation/Conversation.h
+++ b/Source/WatsonSdk/Public/Services/Conversation/Conversation.h
@@ -15,6 +15,7 @@ UCLASS()
 class WATSONSDK_API UConversation : public UObject
 {
 	GENERATED_BODY()
+
 public:
 	FAuthorization Authorization;
 	FConfiguration Configuration;

--- a/Source/WatsonSdk/Public/Services/Conversation/MessageDataModel.h
+++ b/Source/WatsonSdk/Public/Services/Conversation/MessageDataModel.h
@@ -6,7 +6,10 @@ USTRUCT()
 struct FConversationContext
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString conversation_id;
+
+	UPROPERTY()
+	FString conversation_id;
+	
 	FConversationContext() {}
 };
 
@@ -14,8 +17,13 @@ USTRUCT()
 struct FConversationRuntimeIntent
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString intent;
-	UPROPERTY() float confidence;
+
+	UPROPERTY()
+	FString intent;
+	
+	UPROPERTY()
+	float confidence;
+	
 	FConversationRuntimeIntent() {}
 };
 
@@ -23,10 +31,19 @@ USTRUCT()
 struct FConversationRuntimeEntity
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString entity;
-	UPROPERTY() TArray<int32> location;
-	UPROPERTY() FString value;
-	UPROPERTY() float confidence;
+	
+	UPROPERTY()
+	FString entity;
+	
+	UPROPERTY()
+	TArray<int32> location;
+	
+	UPROPERTY()
+	FString value;
+	
+	UPROPERTY()
+	float confidence;
+	
 	FConversationRuntimeEntity() {}
 };
 
@@ -34,8 +51,13 @@ USTRUCT()
 struct FConversationLogMessage
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString level;
-	UPROPERTY() FString msg;
+	
+	UPROPERTY()
+	FString level;
+	
+	UPROPERTY()
+	FString msg;
+	
 	FConversationLogMessage() {}
 };
 
@@ -43,9 +65,16 @@ USTRUCT()
 struct FConversationOutputData
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() TArray<FConversationLogMessage> log_messages;
-	UPROPERTY() TArray<FString> text;
-	UPROPERTY() TArray<FString> nodes_visited;
+
+	UPROPERTY()
+	TArray<FConversationLogMessage> log_messages;
+	
+	UPROPERTY()
+	TArray<FString> text;
+	
+	UPROPERTY()
+	TArray<FString> nodes_visited;
+	
 	FConversationOutputData() {}
 };
 
@@ -53,7 +82,10 @@ USTRUCT()
 struct FConversationInputData
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString text;
+
+	UPROPERTY()
+	FString text;
+	
 	FConversationInputData() {}
 };
 
@@ -61,12 +93,25 @@ USTRUCT()
 struct FConversationMessageRequest
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FConversationInputData input;
-	UPROPERTY() bool alternate_intents;
-	UPROPERTY() FConversationContext context;
-	UPROPERTY() TArray<FConversationRuntimeEntity> entities;
-	UPROPERTY() TArray<FConversationRuntimeIntent> intents;
-	UPROPERTY() FConversationOutputData output;
+
+	UPROPERTY()
+	FConversationInputData input;
+	
+	UPROPERTY()
+	bool alternate_intents;
+	
+	UPROPERTY()
+	FConversationContext context;
+	
+	UPROPERTY()
+	TArray<FConversationRuntimeEntity> entities;
+	
+	UPROPERTY()
+	TArray<FConversationRuntimeIntent> intents;
+	
+	UPROPERTY()
+	FConversationOutputData output;
+	
 	FConversationMessageRequest() {}
 };
 
@@ -74,7 +119,10 @@ USTRUCT()
 struct FConversationMessageInput
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString text;
+
+	UPROPERTY()
+	FString text;
+	
 	FConversationMessageInput() {}
 };
 
@@ -82,12 +130,25 @@ USTRUCT()
 struct FConversationMessageResponse
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FConversationMessageInput input;
-	UPROPERTY() TArray<FConversationRuntimeIntent> intents;
-	UPROPERTY() TArray<FConversationRuntimeEntity> entities;
-	UPROPERTY() bool alternate_intents;
-	UPROPERTY() FConversationContext context;
-	UPROPERTY() FConversationOutputData output;
+	
+	UPROPERTY()
+	FConversationMessageInput input;
+	
+	UPROPERTY()
+	TArray<FConversationRuntimeIntent> intents;
+	
+	UPROPERTY()
+	TArray<FConversationRuntimeEntity> entities;
+	
+	UPROPERTY()
+	bool alternate_intents;
+	
+	UPROPERTY()
+	FConversationContext context;
+	
+	UPROPERTY()
+	FConversationOutputData output;
+	
 	FConversationMessageResponse() {}
 };
 
@@ -95,8 +156,13 @@ USTRUCT()
 struct FConversationMessageErrorDetail
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString message;
-	UPROPERTY() FString path;
+	
+	UPROPERTY()
+	FString message;
+	
+	UPROPERTY()
+	FString path;
+	
 	FConversationMessageErrorDetail() {}
 };
 
@@ -104,7 +170,12 @@ USTRUCT()
 struct FConversationMessageError
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString error;
-	UPROPERTY() TArray<FConversationMessageErrorDetail> errors;
+	
+	UPROPERTY()
+	FString error;
+	
+	UPROPERTY()
+	TArray<FConversationMessageErrorDetail> errors;
+
 	FConversationMessageError() {}
 };

--- a/Source/WatsonSdk/Public/Services/Conversation/MessageDataModel.h
+++ b/Source/WatsonSdk/Public/Services/Conversation/MessageDataModel.h
@@ -8,7 +8,7 @@ struct FConversationContext
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString conversation_id;
+	FString ConversationId;
 	
 	FConversationContext() {}
 };
@@ -19,10 +19,10 @@ struct FConversationRuntimeIntent
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString intent;
+	FString Intent;
 	
 	UPROPERTY()
-	float confidence;
+	float Confidence;
 	
 	FConversationRuntimeIntent() {}
 };
@@ -33,16 +33,16 @@ struct FConversationRuntimeEntity
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	FString entity;
+	FString Entity;
 	
 	UPROPERTY()
-	TArray<int32> location;
+	TArray<int32> Location;
 	
 	UPROPERTY()
-	FString value;
+	FString Value;
 	
 	UPROPERTY()
-	float confidence;
+	float Confidence;
 	
 	FConversationRuntimeEntity() {}
 };
@@ -53,10 +53,10 @@ struct FConversationLogMessage
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	FString level;
+	FString Level;
 	
 	UPROPERTY()
-	FString msg;
+	FString Msg;
 	
 	FConversationLogMessage() {}
 };
@@ -67,13 +67,13 @@ struct FConversationOutputData
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	TArray<FConversationLogMessage> log_messages;
+	TArray<FConversationLogMessage> LogMessages;
 	
 	UPROPERTY()
-	TArray<FString> text;
+	TArray<FString> Text;
 	
 	UPROPERTY()
-	TArray<FString> nodes_visited;
+	TArray<FString> NodesVisited;
 	
 	FConversationOutputData() {}
 };
@@ -84,7 +84,7 @@ struct FConversationInputData
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString text;
+	FString Text;
 	
 	FConversationInputData() {}
 };
@@ -95,22 +95,22 @@ struct FConversationMessageRequest
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FConversationInputData input;
+	FConversationInputData Input;
 	
 	UPROPERTY()
-	bool alternate_intents;
+	bool AlternateIntents;
 	
 	UPROPERTY()
-	FConversationContext context;
+	FConversationContext Context;
 	
 	UPROPERTY()
-	TArray<FConversationRuntimeEntity> entities;
+	TArray<FConversationRuntimeEntity> Entities;
 	
 	UPROPERTY()
-	TArray<FConversationRuntimeIntent> intents;
+	TArray<FConversationRuntimeIntent> Intents;
 	
 	UPROPERTY()
-	FConversationOutputData output;
+	FConversationOutputData Output;
 	
 	FConversationMessageRequest() {}
 };
@@ -121,7 +121,7 @@ struct FConversationMessageInput
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString text;
+	FString Text;
 	
 	FConversationMessageInput() {}
 };
@@ -132,22 +132,22 @@ struct FConversationMessageResponse
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	FConversationMessageInput input;
+	FConversationMessageInput Input;
 	
 	UPROPERTY()
-	TArray<FConversationRuntimeIntent> intents;
+	TArray<FConversationRuntimeIntent> Intents;
 	
 	UPROPERTY()
-	TArray<FConversationRuntimeEntity> entities;
+	TArray<FConversationRuntimeEntity> Entities;
 	
 	UPROPERTY()
-	bool alternate_intents;
+	bool AlternateIntents;
 	
 	UPROPERTY()
-	FConversationContext context;
+	FConversationContext Context;
 	
 	UPROPERTY()
-	FConversationOutputData output;
+	FConversationOutputData Output;
 	
 	FConversationMessageResponse() {}
 };
@@ -158,10 +158,10 @@ struct FConversationMessageErrorDetail
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	FString message;
+	FString Message;
 	
 	UPROPERTY()
-	FString path;
+	FString Path;
 	
 	FConversationMessageErrorDetail() {}
 };
@@ -172,10 +172,10 @@ struct FConversationMessageError
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	FString error;
+	FString Error;
 	
 	UPROPERTY()
-	TArray<FConversationMessageErrorDetail> errors;
+	TArray<FConversationMessageErrorDetail> Errors;
 
 	FConversationMessageError() {}
 };

--- a/Source/WatsonSdk/Public/Services/SpeechToText/RecognizeDataModel.h
+++ b/Source/WatsonSdk/Public/Services/SpeechToText/RecognizeDataModel.h
@@ -6,10 +6,19 @@ USTRUCT()
 struct FKeywordResult
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString normalized_text;
-	UPROPERTY() int32 start_time;
-	UPROPERTY() int32 end_time;
-	UPROPERTY() int32 confidence;
+
+	UPROPERTY()
+	FString normalized_text;
+
+	UPROPERTY()
+	int32 start_time;
+
+	UPROPERTY()
+	int32 end_time;
+
+	UPROPERTY()
+	int32 confidence;
+
 	FKeywordResult() {}
 };
 
@@ -17,11 +26,22 @@ USTRUCT()
 struct FSpeakerLabelsResult
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() int32 from;
-	UPROPERTY() int32 to;
-	UPROPERTY() int32 speaker;
-	UPROPERTY() int32 confidence;
-	//UPROPERTY() bool final;
+
+	UPROPERTY()
+	int32 from;
+
+	UPROPERTY()
+	int32 to;
+
+	UPROPERTY()
+	int32 speaker;
+
+	UPROPERTY()
+	int32 confidence;
+
+	//UPROPERTY()
+	//bool final;
+
 	FSpeakerLabelsResult() {}
 };
 
@@ -29,10 +49,19 @@ USTRUCT()
 struct FSpeechRecognitionAlternative
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString transcript;
-	UPROPERTY() int32 confidence;
-	UPROPERTY() TArray<FString> timestamps;
-	UPROPERTY() TArray<FString> word_confidence;
+
+	UPROPERTY()
+	FString transcript;
+
+	UPROPERTY()
+	int32 confidence;
+
+	UPROPERTY()
+	TArray<FString> timestamps;
+
+	UPROPERTY()
+	TArray<FString> word_confidence;
+
 	FSpeechRecognitionAlternative() {}
 };
 
@@ -40,8 +69,13 @@ USTRUCT()
 struct FWordAlternativeResult
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() int32 confidence;
-	UPROPERTY() FString word;
+
+	UPROPERTY()
+	int32 confidence;
+
+	UPROPERTY()
+	FString word;
+
 	FWordAlternativeResult() {}
 };
 
@@ -49,9 +83,16 @@ USTRUCT()
 struct FWordAlternativeResults
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() int32 start_time;
-	UPROPERTY() int32 end_time;
-	UPROPERTY() TArray<FWordAlternativeResult> alternatives;
+
+	UPROPERTY()
+	int32 start_time;
+
+	UPROPERTY()
+	int32 end_time;
+
+	UPROPERTY()
+	TArray<FWordAlternativeResult> alternatives;
+
 	FWordAlternativeResults() {}
 };
 
@@ -59,10 +100,19 @@ USTRUCT()
 struct FSpeechRecognitionResult
 {
 	GENERATED_USTRUCT_BODY()
-	//UPROPERTY() bool final;
-	UPROPERTY() TArray<FSpeechRecognitionAlternative> alternatives;
-	UPROPERTY() TMap<FString, FKeywordResult> keyword_results;
-	UPROPERTY() TArray<FWordAlternativeResults> word_alternatives;
+
+	//UPROPERTY()
+	//bool final;
+
+	UPROPERTY()
+	TArray<FSpeechRecognitionAlternative> alternatives;
+
+	UPROPERTY()
+	TMap<FString, FKeywordResult> keyword_results;
+
+	UPROPERTY()
+	TArray<FWordAlternativeResults> word_alternatives;
+
 	FSpeechRecognitionResult() {}
 };
 
@@ -70,10 +120,19 @@ USTRUCT()
 struct FSpeechRecognitionEvent
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() TArray<FSpeechRecognitionResult> results;
-	UPROPERTY() int32 result_index;
-	UPROPERTY() TArray<FSpeakerLabelsResult> speaker_labels;
-	UPROPERTY() TArray<FString> warnings;
+
+	UPROPERTY()
+	TArray<FSpeechRecognitionResult> results;
+
+	UPROPERTY()
+	int32 result_index;
+
+	UPROPERTY()
+	TArray<FSpeakerLabelsResult> speaker_labels;
+
+	UPROPERTY()
+	TArray<FString> warnings;
+
 	FSpeechRecognitionEvent() {}
 };
 
@@ -81,10 +140,19 @@ USTRUCT()
 struct FSpeechToTextError
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString error;
-	UPROPERTY() int32 code;
-	UPROPERTY() FString code_description;
-	UPROPERTY() TArray<FString> warnings;
+
+	UPROPERTY()
+	FString error;
+
+	UPROPERTY()
+	int32 code;
+
+	UPROPERTY()
+	FString code_description;
+
+	UPROPERTY()
+	TArray<FString> warnings;
+
 	FSpeechToTextError() {}
 };
 

--- a/Source/WatsonSdk/Public/Services/SpeechToText/RecognizeDataModel.h
+++ b/Source/WatsonSdk/Public/Services/SpeechToText/RecognizeDataModel.h
@@ -8,16 +8,16 @@ struct FKeywordResult
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString normalized_text;
+	FString NormalizedText;
 
 	UPROPERTY()
-	int32 start_time;
+	int32 StartTime;
 
 	UPROPERTY()
-	int32 end_time;
+	int32 EndTime;
 
 	UPROPERTY()
-	int32 confidence;
+	int32 Confidence;
 
 	FKeywordResult() {}
 };
@@ -28,19 +28,19 @@ struct FSpeakerLabelsResult
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	int32 from;
+	int32 From;
 
 	UPROPERTY()
-	int32 to;
+	int32 To;
 
 	UPROPERTY()
-	int32 speaker;
+	int32 Speaker;
 
 	UPROPERTY()
-	int32 confidence;
+	int32 Confidence;
 
 	//UPROPERTY()
-	//bool final;
+	//bool Final;
 
 	FSpeakerLabelsResult() {}
 };
@@ -51,16 +51,16 @@ struct FSpeechRecognitionAlternative
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString transcript;
+	FString Transcript;
 
 	UPROPERTY()
-	int32 confidence;
+	int32 Confidence;
 
 	UPROPERTY()
-	TArray<FString> timestamps;
+	TArray<FString> Timestamps;
 
 	UPROPERTY()
-	TArray<FString> word_confidence;
+	TArray<FString> WordConfidence;
 
 	FSpeechRecognitionAlternative() {}
 };
@@ -71,10 +71,10 @@ struct FWordAlternativeResult
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	int32 confidence;
+	int32 Confidence;
 
 	UPROPERTY()
-	FString word;
+	FString Word;
 
 	FWordAlternativeResult() {}
 };
@@ -85,13 +85,13 @@ struct FWordAlternativeResults
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	int32 start_time;
+	int32 StartTime;
 
 	UPROPERTY()
-	int32 end_time;
+	int32 EndTime;
 
 	UPROPERTY()
-	TArray<FWordAlternativeResult> alternatives;
+	TArray<FWordAlternativeResult> Alternatives;
 
 	FWordAlternativeResults() {}
 };
@@ -102,7 +102,7 @@ struct FSpeechRecognitionResult
 	GENERATED_USTRUCT_BODY()
 
 	//UPROPERTY()
-	//bool final;
+	//bool Final;
 
 	UPROPERTY()
 	TArray<FSpeechRecognitionAlternative> alternatives;
@@ -122,16 +122,16 @@ struct FSpeechRecognitionEvent
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	TArray<FSpeechRecognitionResult> results;
+	TArray<FSpeechRecognitionResult> Results;
 
 	UPROPERTY()
-	int32 result_index;
+	int32 ResultIndex;
 
 	UPROPERTY()
-	TArray<FSpeakerLabelsResult> speaker_labels;
+	TArray<FSpeakerLabelsResult> SpeakerLabels;
 
 	UPROPERTY()
-	TArray<FString> warnings;
+	TArray<FString> Warnings;
 
 	FSpeechRecognitionEvent() {}
 };
@@ -142,16 +142,16 @@ struct FSpeechToTextError
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString error;
+	FString Error;
 
 	UPROPERTY()
-	int32 code;
+	int32 Code;
 
 	UPROPERTY()
-	FString code_description;
+	FString CodeDescription;
 
 	UPROPERTY()
-	TArray<FString> warnings;
+	TArray<FString> Warnings;
 
 	FSpeechToTextError() {}
 };

--- a/Source/WatsonSdk/Public/Services/SpeechToText/SpeechToText.h
+++ b/Source/WatsonSdk/Public/Services/SpeechToText/SpeechToText.h
@@ -14,6 +14,7 @@ UCLASS()
 class WATSONSDK_API USpeechToText : public UObject
 {
 	GENERATED_BODY()
+
 public:
 	FAuthorization Authorization;
 	FConfiguration Configuration;

--- a/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
+++ b/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
@@ -33,10 +33,10 @@ struct FSynthesizeError
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString error;
+	FString Error;
 
 	UPROPERTY()
-	int32 code;
+	int32 Code;
 
 	FSynthesizeError() {}
 };

--- a/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
+++ b/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
@@ -6,7 +6,10 @@ USTRUCT()
 struct FSynthesizeRequest
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString text;
+
+	UPROPERTY()
+	FString text;
+
 	FSynthesizeRequest() {}
 };
 
@@ -14,8 +17,13 @@ USTRUCT()
 struct FSynthesizeResponse
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() TArray<uint8> audioData;
-	UPROPERTY() uint32 audioLength;
+
+	UPROPERTY()
+	TArray<uint8> audioData;
+
+	UPROPERTY()
+	uint32 audioLength;
+
 	FSynthesizeResponse() {}
 };
 
@@ -23,8 +31,13 @@ USTRUCT()
 struct FSynthesizeError
 {
 	GENERATED_USTRUCT_BODY()
-	UPROPERTY() FString error;
-	UPROPERTY() int32 code;
+
+	UPROPERTY()
+	FString error;
+
+	UPROPERTY()
+	int32 code;
+
 	FSynthesizeError() {}
 };
 

--- a/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
+++ b/Source/WatsonSdk/Public/Services/TextToSpeech/SynthesizeDataModel.h
@@ -8,7 +8,7 @@ struct FSynthesizeRequest
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	FString text;
+	FString Text;
 
 	FSynthesizeRequest() {}
 };
@@ -19,10 +19,10 @@ struct FSynthesizeResponse
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	TArray<uint8> audioData;
+	TArray<uint8> AudioData;
 
 	UPROPERTY()
-	uint32 audioLength;
+	uint32 AudioLength;
 
 	FSynthesizeResponse() {}
 };

--- a/Source/WatsonSdk/Public/Services/TextToSpeech/TextToSpeech.h
+++ b/Source/WatsonSdk/Public/Services/TextToSpeech/TextToSpeech.h
@@ -12,6 +12,7 @@ UCLASS()
 class WATSONSDK_API UTextToSpeech : public UObject
 {
 	GENERATED_BODY()
+
 public:
 	FAuthorization Authorization;
 	FConfiguration Configuration;

--- a/Source/WatsonSdk/WatsonSdk.Build.cs
+++ b/Source/WatsonSdk/WatsonSdk.Build.cs
@@ -46,12 +46,13 @@ public class WatsonSdk : ModuleRules
 			{
 				"CoreUObject",
 				"Engine",
+                "WebSockets",
 				//"Slate",
                 //"SlateCore",
 
 				// ... add private dependencies that you statically link with here ...	
 			}
-			);
+            );
 		
 		
 		DynamicallyLoadedModuleNames.AddRange(


### PR DESCRIPTION
I updated the plugin to more closely match Epic's [https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/](coding standard).

One thing that I didn't address is that Epic's style also normally has the public constructors and functions at the top of the class/struct followed by any public variables. I didn't change any of those!