### PR TITLE
Added header file to MyPawn.cpp example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ protected:
 // Make sure to create a Microphone Action Mapping for push-to-talk behavior.
 
 #include "MyPawn.h"
+#include "Components/InputComponent.h"
 
 AMyPawn::AMyPawn()
 {


### PR DESCRIPTION
Added #include "Components/InputComponent.h"to the MyPawn.cpp example code to fix an input binding compiling error.